### PR TITLE
Removed asMap() from WsPacketWrapper.java

### DIFF
--- a/endertranslate-core/src/main/java/fr/supermax_8/endertranslate/core/communication/WsPacketWrapper.java
+++ b/endertranslate-core/src/main/java/fr/supermax_8/endertranslate/core/communication/WsPacketWrapper.java
@@ -29,7 +29,7 @@ public class WsPacketWrapper {
         public WsPacketWrapper deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
             JsonObject jsonObject = null;
             String type = null;
-            for (Map.Entry<String, JsonElement> entry : json.getAsJsonObject().asMap().entrySet()) {
+            for (Map.Entry<String, JsonElement> entry : json.getAsJsonObject().entrySet()) {
                 type = entry.getKey();
                 jsonObject = entry.getValue().getAsJsonObject();
                 break;


### PR DESCRIPTION
I was trying to run EnderTranslate on my Paper 1.16.5 server but I have noticed an error in the startup due to a missing method:
`JsonObject#asMap()`. Older Spigot versions use older gson libraries and the `asMap()` method has been added only in gson [v2.10](https://www.javadoc.io/doc/com.google.code.gson/gson/2.10/com.google.gson/com/google/gson/JsonObject.html#asMap()).

The `asMap()` call WsPacketWrapper.java can be easily removed as `JsonObject` itself contains a `entrySet()` method which actually works just as if `asMap().entrySet()` was called: see the source code [here](https://github.com/google/gson/blob/main/gson/src/main/java/com/google/gson/JsonObject.java#L136-L138) and [here](https://github.com/google/gson/blob/main/gson/src/main/java/com/google/gson/JsonObject.java#L237-L240).

If you replace this method, hopefully the plugin will work on older versions too! 🙂